### PR TITLE
Add logos

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,6 +14,7 @@
     </div>
 
     {% include footer.html %}
+    {{ page.end_scripts }}
 
   </body>
 

--- a/_sass/_logos.scss
+++ b/_sass/_logos.scss
@@ -1,0 +1,40 @@
+.intro-text {
+  max-width: 540px;
+  font-size: 1.2em;
+  text-align: center;
+  margin: 2rem auto 3em;
+}
+
+.possible-logos ul {
+  margin: 0;
+
+  li{
+    width: 30%;
+    margin: 1%;
+    display: inline-block;
+    vertical-align: top;
+  }
+
+  .src {
+    text-align: center;
+    width: 100%;
+    display: block;
+    margin-bottom: 2em;
+  }
+
+  a {
+    width: 100%;
+    display: block;
+    text-align: center;
+  }
+
+  a:hover {
+    text-decoration: none;
+    border-bottom: none;
+  }
+
+  img {
+    margin: 0 auto;
+    width: 80%;
+  }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -48,7 +48,9 @@ $on-laptop:        800px;
 @import
         "base",
         "layout",
+        "logos",
         "syntax-highlighting"
+
 ;
 
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class="home">
   <div class="frontpage">
-    <h1>Bringing together great design & open source</h1>
+    <h1>Bringing together great design &amp; open source</h1>
 
     <h3>We are a community of designers and developers aiming to push more open design processes and improve the design of open source apps</h3>
   </div>

--- a/js/site.js
+++ b/js/site.js
@@ -9,7 +9,7 @@ function foo(response) {
   var events = {
     CommitCommentEvent: "commented on a commit",
     CreateEvent: "created something",
-    DeleteEvent: "deleted something", 
+    DeleteEvent: "deleted something",
     DeploymentEvent: "deployment event",
     DeploymentStatusEvent: "deployment status",
     DownloadEvent: "new download created",
@@ -53,3 +53,32 @@ var script = document.createElement('script');
 script.src = 'https://api.github.com/repos/opensourcedesign/opensourcedesign.github.io/events?callback=foo';
 
 document.getElementsByTagName('head')[0].appendChild(script);
+
+
+/*
+ * parse_link_header()
+ *
+ * Parse the Github Link HTTP header used for pageination
+ * http://developer.github.com/v3/#pagination
+ */
+function parse_link_header(header) {
+  if (header.length == 0) {
+    throw new Error("input must not be of zero length");
+  }
+
+  // Split parts by comma
+  var parts = header.split(',');
+  var links = {};
+  // Parse each part into a named link
+  _.each(parts, function(p) {
+    var section = p.split(';');
+    if (section.length != 2) {
+      throw new Error("section could not be split on ';'");
+    }
+    var url = section[0].replace(/<(.*)>/, '$1').trim();
+    var name = section[1].replace(/rel="(.*)"/, '$1').trim();
+    links[name] = url;
+  });
+
+  return links;
+}

--- a/logos.html
+++ b/logos.html
@@ -63,6 +63,10 @@ end_scripts: |
   </script>
 ---
 
+<p class="intro-text">
+  We've been talking about our logo, what it should be, and what it should look like. Below is a dynamically created list of all the proposals put forth in the Github thread:
+</p>
+
 <div id="logos" class="possible-logos">
 </div>
 

--- a/logos.html
+++ b/logos.html
@@ -1,0 +1,77 @@
+---
+layout: default
+end_scripts: |
+  <script>
+    (function() {
+      var getComments = function(nextCommentsURL, comments) {
+        $.get(nextCommentsURL, function(responseComments, status, jqxhr) {
+
+          var linksHeader = jqxhr.getResponseHeader('Link');
+          var nextCommentsURL = parse_link_header(linksHeader).next;
+
+          comments = comments.concat(responseComments);
+          if (nextCommentsURL) {
+            getComments(nextCommentsURL, comments)
+          } else {
+            buildIssues(comments);
+          }
+        });
+      }
+
+      var buildIssues = function(allComments){
+        console.log("done fetching, building", allComments);
+        var images_html = '';
+        var template_item = _.template($('#logo-list-item').html());
+
+        var index_counter = 1;
+        _.forEach(allComments, function(comment) {
+          var re = /!\[(.*?)\]\((.*?)\)/g;
+          var instances = [];
+          var result = [];
+
+          while ((result = re.exec(comment.body))) {
+            if (result[2] && result[1].indexOf('smallicons') === -1 && result[1].indexOf('scribus') === -1) {
+              images_html += template_item({
+                index: index_counter,
+                comment_url: comment.html_url,
+                image_url: result[2]
+              });
+              console.log(comment.body);
+              index_counter += 1;
+            }
+          }
+        });
+
+        $('#logos').html('<ul>' + images_html + '</ul>');
+
+      }
+
+      var issueUrl = 'https://api.github.com/repos/opensourcedesign/' +
+                     'opensourcedesign.github.io/issues/18';
+
+      $.get(issueUrl, function(issue, status, jqxhr) {
+          var created = issue.created_at;
+          var baseCommentsURL = issueUrl + '/comments';
+          var comments = [];
+
+          getComments(baseCommentsURL, comments);
+
+        }).fail(function(error){
+          console.log('error', error.statusText, error.getAllResponseHeaders());
+        });
+    })()
+  </script>
+---
+
+<div id="logos" class="possible-logos">
+</div>
+
+<script id="logo-list-item" type="text/template">
+  <li>
+
+    <a href="<%= comment_url %>">
+      <img src="<%= image_url %>" alt="logo option"/>
+      <span class="src"><%= index %></span>
+    </a>
+  </li>
+</script>


### PR DESCRIPTION
# What's changed
* Some sneakery to have an endscript in a specific page.
* A logos page that takes all the images shown in #18 and puts them up on their own page, without all the talk.
![screenshot 2015-06-28 15 50 37](https://cloud.githubusercontent.com/assets/485583/8398888/72601002-1dad-11e5-9196-be84dc86059d.png)

Though I just noticed that this doesn't include the images posted in the actual issue title, I will do another PR for those.