### PR TITLE
Fixes extremely tight line-heights in headings.

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -254,7 +254,7 @@
 .post-title {
     font-size: 42px;
     letter-spacing: -1px;
-    line-height: 50px;
+    line-height: 1.2;
 
     @include media-query($on-laptop) {
         font-size: 36px;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -254,7 +254,7 @@
 .post-title {
     font-size: 42px;
     letter-spacing: -1px;
-    line-height: 1;
+    line-height: 50px;
 
     @include media-query($on-laptop) {
         font-size: 36px;


### PR DESCRIPTION

<img width="710" alt="screen shot 2015-08-30 at 11 46 03 am" src="https://cloud.githubusercontent.com/assets/992488/9566649/0b407c36-4f0d-11e5-8121-22a39c76fc1d.png">

Post title headings like above are very tight at the moment, there are content overlaps here and there. So, this PR addresses that. Check.