### PR TITLE
Hide Brand When Dark Nav Bar Isn't Shown

### DIFF
--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -15,6 +15,7 @@
     padding: 15px 15px 8px;
     color: $background-color;
     line-height: inherit;
+    opacity: 0;
 
     &:focus {
       outline: none;
@@ -31,6 +32,10 @@
       }
     }
   }
+  
+.navbar.navbar-custom.navbar-fixed-top.top-nav-collapse a.navbar-brand.page-scroll {
+  opacity: 100 !important;
+}
 
   a {
     color: $grayscale-dark;


### PR DESCRIPTION
I could still see the logo when I was scrolled to the very top. (See below)
![osdlogo](https://cloud.githubusercontent.com/assets/5341898/11454560/e6ce9558-95e4-11e5-9f88-7e4c09a8b5bb.png)


I think this works. Maybe someone more familar with SCSS on this code could fit it in better into the code?