### PR TITLE
Update 2015-04-25-welcome-to-open-source-design.markdown

### DIFF
--- a/_posts/2015-04-25-welcome-to-open-source-design.markdown
+++ b/_posts/2015-04-25-welcome-to-open-source-design.markdown
@@ -3,6 +3,8 @@ layout: post
 title:  "Welcome to Open Source Design"
 date:   2015-04-25
 categories: design, open source, launching
+redirect_from: "/design,/open/source,/launching/2015/04/25/welcome-to-open-source-design.html"
+permalink: "/2015/04/25/welcome-to-open-source-design"
 ---
 
 Here should be our hello world blog post :)

--- a/_posts/2015-04-25-welcome-to-open-source-design.markdown
+++ b/_posts/2015-04-25-welcome-to-open-source-design.markdown
@@ -2,9 +2,9 @@
 layout: post
 title:  "Welcome to Open Source Design"
 date:   2015-04-25
-categories: design, open source, launching
-redirect_from: "/design,/open/source,/launching/2015/04/25/welcome-to-open-source-design.html"
-permalink: "/2015/04/25/welcome-to-open-source-design"
+categories: design open source launching
+redirect_from: /design,/open/source,/launching/2015/04/25/welcome-to-open-source-design.html
+permalink: /2015/04/25/welcome-to-open-source-design
 ---
 
 Here should be our hello world blog post :)

--- a/_posts/2015-05-18-this-month-in-open-source-design.markdown
+++ b/_posts/2015-05-18-this-month-in-open-source-design.markdown
@@ -1,8 +1,10 @@
 ---
 layout: post
-date: 2015-05-18-15-37
+date: 2015-05-18
 title: "This Month in Open Source Design"
 category: monthly-update
+redirect_from: /monthly-update/2015/05/18/this-month-in-open-source-design.html
+permalink: /2015/05/18/this-month-in-open-source-design
 ---
 
 # In IRC

--- a/_posts/2015-05-24-TextbasedToolsForDesigners.markdown
+++ b/_posts/2015-05-24-TextbasedToolsForDesigners.markdown
@@ -3,6 +3,8 @@ layout: post
 date: 2015-05-23
 title: "Why open source designers need tools beyond text and code"
 category: 
+redirect_from: /2015/05/23/TextbasedToolsForDesigners.html
+permalink: /2015/05/23/text-based-tools-for-designers
 ---
 
 Text is the predominant means of creating and collaborating on software. Design is a visual and spacial activity. For those who design software and websites there is a non-visual world that needs to be navigated and taken into account: text in the form of program code and comments.

--- a/_posts/2015-07-10-this-month-in-open-source-design.markdown
+++ b/_posts/2015-07-10-this-month-in-open-source-design.markdown
@@ -3,6 +3,8 @@ layout: post
 date: 2015-07-10-20-00
 title: "This Month in Open Source Design - June (and some bits of July and May)"
 category: monthly-update
+redirect_from: /monthly-update/2015/07/10/this-month-in-open-source-design.html
+permalink: /2015/07/10/this-month-in-open-source-design
 ---
 
 # In IRC

--- a/_posts/2015-11-21-5-steps-to-design-a-ux-that-people-love.md
+++ b/_posts/2015-11-21-5-steps-to-design-a-ux-that-people-love.md
@@ -3,6 +3,8 @@ layout: post
 title:  "5 Steps to Design a UX that People Love"
 date:   2015-11-21
 categories: design open-source ux user-experience
+redirect_from: /design/open-source/ux/user-experience/2015/11/21/5-steps-to-design-a-ux-that-people-love.html
+permalink: /2015/11/21/5-steps-to-design-a-ux-that-people-love
 ---
 
 ## Research, prototyping, and testing. The easy way.


### PR DESCRIPTION
updated all permal links to shorter urls as discussed in [events issue #26](https://github.com/opensourcedesign/events/issues/26)
also added a redirect of the old links to the new perma links