### PR TITLE
Add footer link to CoC

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -33,6 +33,10 @@
     <li>
       <a href="http://chat.opensourcedesign.net/">Chat With Us</a>
     </li>
+
+    <li>
+      <a href="http://opensourcedesign.net/code-of-conduct/">Code of Conduct</a>
+    </li>
   </ul>
 
 </footer>


### PR DESCRIPTION
It looks like we are not linking to our Code of Conduct from anywhere. Adding a link in the footer for the time being, until we find a better place for it.

Signed-off-by: Belen Pena <belenbarrospena@gmail.com>