### PR TITLE
Reinforce link hover style

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -136,7 +136,7 @@ a {
 
   &:hover,
   &:focus {
-    text-decoration: none;
+    text-decoration: underline;
     color: darken($grayscale-primary,0.2);
   }
 }


### PR DESCRIPTION
Our links seem to have a very subtle hover style: the text colour darkens very slighly when you hover over a link.

The change is so subtle, that at the beginning I thought the links didn't change at all. I only discovered there was a hover style by looking at the css.

We should probably make the hover state a bit more obvious. Simplest thing is to underline the link text on hover, as this patch does.

Signed-off-by: Belen Pena <belenbarrospena@gmail.com>