### PR TITLE
fix links to Julia's Twitter and Github profiles

### DIFF
--- a/_posts/2016-04-04-interview-with-julia.md
+++ b/_posts/2016-04-04-interview-with-julia.md
@@ -86,4 +86,4 @@ Of course the git integration is a great bonus.
 Gimp is really great.
 I believe it still needs a lot more design love in the terms of usability and experience but it's very advanced and you can accomplish a lot with it.
 
-Julia is on [Twitter](https://twitter.com/jlsmp) and [GitHub](github.com/jsimplicio).
+Julia is on [Twitter](https://twitter.com/JulesSimplicio) and [GitHub](https://github.com/jsimplicio).


### PR DESCRIPTION
The GitHub username was correct, but the link is a 404. On Twitter, "jlsmp" seems to be someone else.