### PR TITLE
Missing registration link to Open Collective

### DIFF
--- a/summit/2017.html
+++ b/summit/2017.html
@@ -30,7 +30,9 @@ category: summit
         <div class="col-md-4 col-md-offset-4 center">
             <p>We're organizing a summit for all designers and developers interested in cheerleading great design in open source.</p>
 
-            <p>Interested in attending? Want to get involved? Details are still being worked out, but <a href="https://github.com/opensourcedesign/organization/issues?q=is%3Aissue+is%3Aopen+label%3Asummit" title="GitHub issues about the Open Source Design Summit">join the conversation on GitHub</a>.</p>
+            <p>Interested in attending? <a href="https://opencollective.com/opensourcedesign/events/opensourcedesign-summit" title="Get tickets for the summit">Register!</a></p>
+
+            <p>Want to get involved? Details are still being worked out, but <a href="https://github.com/opensourcedesign/organization/issues?q=is%3Aissue+is%3Aopen+label%3Asummit" title="GitHub issues about the Open Source Design Summit">join the conversation on GitHub</a>.</p>
         </div>
     </div>
 


### PR DESCRIPTION
Before
<img width="395" alt="before" src="https://user-images.githubusercontent.com/629552/28829649-2343331a-76dd-11e7-9cad-b4d5b50ed108.png">

After
<img width="411" alt="after" src="https://user-images.githubusercontent.com/629552/28829654-28304e44-76dd-11e7-99c4-6f8163f927c5.png">
