### PR TITLE
link to webchat.freenode.net rather than chat.opensourcedesign.net

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@ layout: default
                     <a href="https://github.com/{{ site.github_username }}" class="btn btn-default btn-lg"><i class="fa fa-github fa-fw"></i> <span class="network-name">Github</span></a>
                 </li>
                 <li>
-                    <a href="http://chat.opensourcedesign.net/" class="btn btn-default btn-lg"><i class="fa fa-comment fa-fw"></i> <span class="network-name">Chat</span></a>
+                    <a href="https://webchat.freenode.net/?channels=opensourcedesign" class="btn btn-default btn-lg"><i class="fa fa-comment fa-fw"></i> <span class="network-name">Chat</span></a>
                 </li>
                 <li>
                     <a href="https://orgmanager.miguelpiedrafita.com/o/opensourcedesign" class="btn btn-default btn-lg"><i class="fa fa-users fa-fw"></i> <span class="network-name">Join us!</span></a>


### PR DESCRIPTION
http://chat.opensourcedesign.net is down:

<img width="1089" alt="screen shot 2017-08-03 at 7 36 41 am" src="https://user-images.githubusercontent.com/21006/28920138-839a6066-781e-11e7-92e0-2189e9c7a995.png">

See also discussion at https://botbot.me/freenode/opensourcedesign/msg/89347264/