### PR TITLE
Move resources and projects to main page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ _events/
 _jobs/
 _organization/
 _patterns/
-_resources/
 _talks/

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -27,7 +27,13 @@
                         <a class="page-scroll" href="/about/">About</a>
                     </li>
                     <li>
+                        <a class="page-scroll" href="/resources/">Resources</a>
+                    </li>
+                    <li>
                         <a class="page-scroll" href="/articles/">Articles</a>
+                    </li>
+                    <li>
+                        <a class="page-scroll" href="/projects/">Projects</a>
                     </li>
                     <li>
                         <a class="page-scroll" href="/jobs/">Jobs</a>

--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: Projects
+permalink: /projects/
+---
+
+**Open source projects with good design, a design team, and with a nice guide on how to get involved with the design!** Designers of lots of these projects are active in our community and hang out in our [forum](https://discourse.opensourcedesign.net/) too! :)
+
+* [Mozilla](http://mozilla.org), makers of the Firefox browser. Have a [UX blog](https://blog.mozilla.org/ux)
+* [GNOME](http://gnome.org) desktop environment. [Design blogs](http://planet.gnome.org/ux/), [Design wiki](https://wiki.gnome.org/Design)
+* [GitLab](https://about.gitlab.com/) git hosting and code collaboration. [UX designer onboarding page](https://about.gitlab.com/handbook/uxdesigner-onboarding/)
+* [Nextcloud](http://nextcloud.com) data sync & sharing, have a [Design page](https://nextcloud.com/design)
+* [Fedora](http://getfedora.org), [Design blogs](http://planet.fedoraproject.org/design), [Design Team wiki](http://fedoraproject.org/wiki/Design)
+* [Canonical (Ubuntu)](http://ubuntu.com), [Design blog](http://design.canonical.com)
+* [Wordpress](http://wordpress.org), [Design discussion](http://make.wordpress.org/ui/)
+* [Drupal](http://drupal.org), [usability group](https://groups.drupal.org/usability), [UI standards](https://drupal.org/ui-standards)
+* [Diaspora](https://diasporafoundation.org/) decentralized social network, [UI issues on Github](https://github.com/diaspora/diaspora/issues?labels=ui)
+* [MediaGoblin](http://mediagoblin.org/) media platform
+* [BeWelcome](http://www.bewelcome.org/) hospitality platform
+* [Mailpile](http://www.mailpile.is/) mail interface, [Design ideas on Github](https://github.com/pagekite/mailpile/issues?milestone=2)
+* [Ghost](https://ghost.org/) simple blogging platform
+* [Terms of Service; Didn’t Read](http://tosdr.org/) contract rating
+* [Libre Office](https://www.libreoffice.org/), [Design Community](https://www.libreoffice.org/community/design/)
+* [Patternfly](http://www.patternfly.org/) A UI framework for enterprise web applications

--- a/resources.md
+++ b/resources.md
@@ -1,0 +1,192 @@
+---
+layout: post
+title: Resources
+permalink: /resources/
+---
+
+**This is a showcase of the many websites and platforms where you can find openly licensed icons, fonts, image, tools and other resources.** You can use them for any purpose, also commercial (some works have specific licenses, so always make sure it’s fine to use).
+
+## Icons
+
+* [The Noun Project](http://thenounproject.com) CC and purchasable icons.
+* [IcoMoon](http://icomoon.io/) CC icons and free to use icon-font creation
+software.
+* [Pictogramas](http://github.com/adrianmg/pictogramas) Open source free icons
+for personal and commercial purposes.
+* [ToIcon](http://www.toicon.com/) All icons are licensed under a Creative
+Commons.
+* [Inkscape Open Symbols](https://github.com/Xaviju/inkscape-open-symbols) Open
+source icon sets to use as Inkscape symbols.
+* [IconMonstr](http://iconmonstr.com/) A large collection of glyph icons from a
+German artist. Free to use without attribution and free to modify.
+* [FontAwesome](http://fontawesome.io/icons/) The iconic font and CSS toolkit. Free to use. [CDN](https://www.bootstrapcdn.com/fontawesome/). [GitHub](https://github.com/FortAwesome/Font-Awesome).
+
+
+## Fonts
+
+* [The League of Movable Type](https://www.theleagueofmoveabletype.com/)
+* [Open Font Library](http://openfontlibrary.org)
+* [Google Web Fonts](http://google.com/fonts)
+
+
+## Images
+
+* [Unsplash](https://unsplash.com/)
+* [Pexels](http://www.pexels.com/)
+* [Flickr Creative Commons](https://flickr.com/creativecommons/)
+* [Gratisography](http://www.gratisography.com/)
+* [Tinyography](http://www.tinyography.com/)
+* [The Stocks](http://thestocks.im/)
+* [FreeImages](http://www.freeimages.com/)
+* [StockSnap](https://stocksnap.io/)
+* [FindA.Photo](http://finda.photo/)
+* [Pixabay](http://pixabay.com/)
+* [New York Public Library Public Domain
+Images](http://www.nypl.org/research/collections/digital-collections/public-domain?hspace=331354)
+
+
+## Media from big platforms under Creative Commons licenses
+
+* [Creative Commons search](http://search.creativecommons.org)
+* [Wikimedia](https://commons.wikimedia.org/wiki/Main_Page)
+* [Youtube](https://www.youtube.com/creativecommons)
+* [SoundCloud](http://soundcloud.com/creativecommons)
+* [Vimeo Music Store](https://vimeo.com/musicstore)
+
+
+## Design tools
+
+* Use a pen & paper for [mockups and
+prototypes](http://alistapart.com/article/paperprototyping). No hi-fi Photoshop
+work needed.
+* [Draw.io](https://www.draw.io/) (diagrams, mockups)
+* [Pencil](http://pencil.evolus.vn/) (mockups)
+* [Krita](https://krita.org/en/) (art, digital painting)
+* [Blender](https://www.blender.org/) (3d rendering, animation, textures)
+* [Darktable](https://www.darktable.org/) (photo workflow)
+* [GIMP](https://www.gimp.org/) (image manipulation, compositing)
+* [Inkscape](https://inkscape.org/en/) (vector elements, print export)
+* [Synfig](http://synfig.org/) for animation
+* Design discussion on the issue tracker of the project. For example at
+[GitHub](http://github.com) – get an account, identify design issues,
+participate, and open new issues. Establish a »Design« tag on the tracker to
+group these issues, for example like in the [Nextcloud
+issues](https://github.com/nextcloud/core/issues?labels=Design).
+
+## Inspiration
+
+* [UI Interaction Library](http://useyourinterface.com/)
+* [Pattern Tap](http://patterntap.com/)
+* [Codrops](http://tympanus.net/codrops/)
+
+
+## CSS Frameworks
+
+* [Bootstrap](http://getbootstrap.com) Fully featured mature HTML, CSS (LESS) &
+Javascript.
+* [Foundation](http://foundation.zurb.com) Fully featured mature HTML, CSS
+(Sass) & Javascript.
+* [BASCSS](http://www.basscss.com/) Lightning-Fast, Modular CSS for Designers.
+* [Bourbon](http://bourbon.io/) A simple and lightweight mixin library for Sass.
+* [Kickoff](http://tmwagency.github.io/kickoff/) A lightweight front-end
+framework for creating scalable, responsive sites.
+* [Space Base](http://spacebase.space150.com/) A sass-based responsive css
+framework.
+* [Rebar](http://github.com/brennannovak/rebar) Simple lightweight HTML, CSS
+(LESS)
+
+
+## General Design Reads
+* [First Rule of Usability? Don’t Listen to
+Users](http://www.nngroup.com/articles/first-rule-of-usability-dont-listen-to-users/)
+by Jakob Nielsen (2001)
+* [10 Heuristics for User Interface
+Design](http://www.nngroup.com/articles/ten-usability-heuristics/) by Jakob
+Nielsen (1995)
+* [19 Principles of User Interface
+Design](http://bokardo.com/principles-of-user-interface-design/) by Joshua
+Porter
+* [ten principles for good design](https://www.vitsoe.com/gb/about/good-design)
+by Dieter Rams (1970s)
+* [A Beginner’s Guide to Finding User
+Needs](http://jdittrich.github.io/userNeedResearchBook/)
+* [Don't Make Me
+Think](http://www.amazon.com/Dont-Make-Me-Think-Usability/dp/0321344758/ref=sr_1_1?s=books&ie=UTF8&qid=1371607999&sr=1-1&keywords=don%27t+make+me+think)
+* [The Design of Everyday
+Things](http://www.amazon.com/Design-Everyday-Things-Donald-Norman/dp/0465067107/ref=sr_1_1?s=books&ie=UTF8&qid=1371607869&sr=1-1&keywords=the+design+of+everyday+things)
+* [Design principles for UI/UX](http://learndesignprinciples.com/)
+
+
+## Open Source and Design Reads
+
+* [Free Software UI (2002)](http://ometer.com/free-software-ui.html)
+* [How Not To Design a
+Portfolio](http://www.alexcornell.com/the-worst-portfolio-ever/)
+* [Open Design Now](http://opendesignnow.org/) book.
+* [Coordinating usability & testing in Free Software (2011)](http://jancborchardt.net/usability-in-free-software) thesis.
+* [How to get designers (or anyone) to work on your open source
+project](http://designopen.org/articles/import-designers/) recent article on
+Design Open.
+* [Barriers Faced by newcomers to open source projects: a systematic
+review](http://www.academia.edu/6537077/Barriers_faced_by_newcomers_to_open_source_projects_a_systematic_review)
+Research Paper.
+* [An Exploration of Fedora's Online Open Source Development
+Community](https://www.academia.edu/4303779/An_Exploration_of_Fedora_s_Online_Open_Source_Development_Community)
+Research Paper.
+* [Designers and women in open
+source](http://old.vi.to/designers-and-women-in-open-source.html) Why designing
+is difficult for Open Source.
+* [Designers, Women, and Hostility in Open Source
+Project](http://smarterware.org/7550/designers-women-and-hostility-in-open-source)
+Follow up to the above article.
+* [Barriers for
+Designers](http://designopen.org/articles/barriers-for-designers/) What barriers
+designers face when contributing to Open Source.
+
+
+## Other nice stuff in the design + open source space
+
+* [Libre Graphics magazine](http://libregraphicsmag.com/) print magazine.
+* [Libre Projects](http://libreprojects.net) collection of nice open source web
+apps.
+* [Libre Graphics World](http://libregraphicsworld.org/)
+* [Libre Graphics Meeting](http://libregraphicsmeeting.org/) conference.
+* [Beautiful Open](http://beautifulopen.com) Beautiful sites for Open Source
+projects.
+* [Open Design and Hardware Group](http://design.okfn.org/). OKFN open design
+and hardware group.
+* [PIXLS.US](https://pixls.us) Free/Open Source Photography.
+* [Photos of Design Research](https://commons.wikimedia.org/wiki/Category:Designethnography) on Wikimedia Commons
+
+
+## Learn to Code
+
+Focused on HTML, CSS, Javascript.) Ideally, to be able to implement your own
+suggestions. But also to better discuss with developers and be understand why
+and how certain things work and don’t work.
+
+* [WebPlatform](http://www.webplatform.org/) web development resources.
+* [Mozilla Developer Network](https://developer.mozilla.org/) for great web dev
+documentation.
+* [Unheap](http://www.unheap.com/) a tidy repository of jQuery plugins.
+* [Transitional Interfaces,
+Coded](http://css-tricks.com/transitional-interfaces-coded/) for good
+animations.
+* [Codecademy](http://www.codecademy.com/) with interactive tutorials.
+* [Try Git](http://try.github.io/) also with interactive tutorials.
+* [code.org](http://code.org/)
+* [Code School](https://www.codeschool.com/) learn even more.
+* [Egghead](http://egghead.io/) to learn the AngularJS framework.
+* [Tota11y](https://github.com/Khan/tota11y) a bookmarklet to check that your
+website is a11y compliant.
+
+
+## Learn to Design
+
+Learn about design concepts! :)
+
+* [Hack Design](https://hackdesign.org/) Free design lessons by inspirational
+designers.
+* [Design Lab](http://trydesignlab.com/) Design course with mentorship and
+projects.
+* [Voice and Tone](http://voiceandtone.com/) Learn about writing good copy.


### PR DESCRIPTION
Basically moving the two pages resources and projects from https://github.com/opensourcedesign/resources/ to the main page. Adding it to the navigation, and adjust it to use the proper style.