### PR TITLE
Remove modified letter spacing

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -105,14 +105,12 @@ h5, .h5,
 h6, .h6 {
   margin: 0 0 35px;
   font-family: $grayscale-headline-font-family;
-  letter-spacing: 1px;
   font-weight: bold;
 }
 
 h3, .h3 {
   margin: 0 0 35px;
   font-family: $grayscale-headline-font-family;
-  letter-spacing: 1px;
   font-weight: bold;
 }
 
@@ -214,7 +212,6 @@ blockquote {
     border-left: 4px solid $grey-color-light;
     padding-left: $spacing-unit / 2;
     font-size: 18px;
-    letter-spacing: -1px;
     font-style: italic;
 
     > :last-child {

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -84,7 +84,6 @@
   .navbar {
     padding: 10px 0;
     border-bottom: none;
-    letter-spacing: 1px;
     background: $background-color;
     -webkit-transition: background .5s ease-in-out,padding .5s ease-in-out;
     -moz-transition: background .5s ease-in-out,padding .5s ease-in-out;
@@ -138,7 +137,6 @@
 .site-title {
     font-size: 26px;
     line-height: 56px;
-    letter-spacing: -1px;
     margin-bottom: 0;
     float: left;
 

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -12,7 +12,6 @@
 
 .post-title {
     font-size: 42px;
-    letter-spacing: -1px;
     line-height: 1.6;
 
     @include media-query($on-laptop) {


### PR DESCRIPTION
Sometimes we used -1px (which looks squished) 
![screenshot from 2017-11-03 15-33-00](https://user-images.githubusercontent.com/925062/32379240-3fb8d544-c0ad-11e7-8996-93fcb76f11c8.png)

and sometimes 1px (also not nice, and inconsistent):
![screenshot from 2017-11-03 15-33-25](https://user-images.githubusercontent.com/925062/32379259-4c760892-c0ad-11e7-8ed0-81bb5261a67a.png)

Not messing with it just looks best.

Check it @simonv3 @bnvk @evalica 