### PR TITLE
Add style for "#floss" div block on /jobs/

### DIFF
--- a/css/jobs.css
+++ b/css/jobs.css
@@ -57,3 +57,7 @@ legend {
 a.btn.disabled {
   pointer-events: auto;
 }
+
+#floss {
+    margin-top: 3rem;
+}


### PR DESCRIPTION
This addresses opensourcedesign/opensourcedesign.github.io#157 by adding the full "Free/Libre and Open Source" moniker, as well as a link to a descriptive paragraph at the end of the page with a more direct explanation (+ links to GNU.org Free Software definition).