### PR TITLE
Link to Riot for chat links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -34,8 +34,8 @@
 	</li>
     {% endif %}
     <li>
-      <a href="http://chat.opensourcedesign.net/">
-          <i class="icon fa fa-comment fa-fw"></i> Chat With Us 
+      <a href="https://riot.im/app/#/room/#opensourcedesign:matrix.org">
+          <i class="icon fa fa-comment fa-fw"></i> Chat With Us
       </a>
     </li>
     <li>

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@ published: true
                     </a>
                 </li>
                 <li>
-                    <a href="https://webchat.freenode.net/?channels=opensourcedesign" class="btn btn-default btn-lg">
+                    <a href="https://riot.im/app/#/room/#opensourcedesign:matrix.org" class="btn btn-default btn-lg">
                         <i class="fa fa-comment fa-fw"></i> <span class="network-name">Chat</span>
                     </a>
                 </li>


### PR DESCRIPTION
I noticed that [Riot is now being used](http://opensourcedesign.net/events/2018/02/OSD-nyc) for OSD. The footer link is broken (`http://chat.opensourcedesign.net/`) and the chat link on the homepage is for IRC. I've updated both links to send the user to #opensourcedesign:matrix.org on Riot.

I know some people will still want to use IRC. Is it still discoverable if we make this change? If not, I think that Matrix should still be the default option and IRC should be conveyed another way, because:

1. It's more accessible to novices.
2. It's prettier.
3. In theory, room history would be shown to the user immediately. I noticed the room settings say "Members only (since they joined)". If you change this to "Anyone", the future room history will show up in the links I've given.
![screenshot from 2018-03-17 15 45 03](https://user-images.githubusercontent.com/3639540/37559322-2c19ea12-29fa-11e8-9314-8a498048721f.png)

**Note about the above:** Every message in Matrix has its own permissions, independent of the room settings. If you change this option, it will make every future message visible to anyone. It will not make past messages visible to anyone. Likewise, changing from "anyone" to a different setting will *not* hide past messages that were shared with "anyone."

By the way, I think these settings should also be changed in Riot:

* The main address for the room should be set to `#opensourcedesign:matrix.org`. Currently it's set to `#freenode_#opensourcedesign:matrix.org`:
![screenshot from 2018-03-17 15 44 05](https://user-images.githubusercontent.com/3639540/37559311-0a588a32-29fa-11e8-9350-de40eef42d0a.png)

* The title can be "Open Source Design" without a hash. It looks weird near my other rooms.
![screenshot from 2018-03-17 15 43 19](https://user-images.githubusercontent.com/3639540/37559298-f0cbc368-29f9-11e8-946d-e23bf0c2d90a.png)
