### PR TITLE
Fix script to match up with info in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@ _site
 .jekyll-metadata
 .bundle
 Gemfile.lock
-_posts/events/
-_posts/jobs/
+events/
+jobs/
 _organization/
 _patterns/
 _talks/

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ _site
 .jekyll-metadata
 .bundle
 Gemfile.lock
-events/
 jobs/
 _organization/
 _patterns/

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -76,14 +76,6 @@ echo -e "\e[94m$LINE\e[0m"
 sleep 1
 
 # Special paths
-if [[ ! -d "events" ]]; then
-	echo -e $MSG_START
-    git clone git@github.com:${USERNAME}/events.git events
-    echo -e $MSG_DONE
-else
-    echo -e $MSG_EXISTS
-fi
-
 if [[ ! -d "jobs" ]]; then
 	echo -e $MSG_START
     git clone git@github.com:${USERNAME}/jobs.git jobs

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -76,17 +76,17 @@ echo -e "\e[94m$LINE\e[0m"
 sleep 1
 
 # Special paths
-if [[ ! -d "_posts/events" ]]; then
+if [[ ! -d "events" ]]; then
 	echo -e $MSG_START
-    git clone git@github.com:${USERNAME}/events.git _posts/events
+    git clone git@github.com:${USERNAME}/events.git events
     echo -e $MSG_DONE
 else
     echo -e $MSG_EXISTS
 fi
 
-if [[ ! -d "_posts/jobs" ]]; then
+if [[ ! -d "jobs" ]]; then
 	echo -e $MSG_START
-    git clone git@github.com:${USERNAME}/jobs.git _posts/jobs
+    git clone git@github.com:${USERNAME}/jobs.git jobs
     echo -e $MSG_DONE
 else
     echo -e $MSG_EXISTS

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,7 +25,7 @@ declare -a REPOS=(
 LINE="--------------------------------------------------------------------------------"
 
 # GH username
-if [[ $1 == "osd" ]]; then
+if [[ $1 == "" ]]; then
     USERNAME="opensourcedesign"
 else
     USERNAME=$1

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -57,7 +57,7 @@ echo -e $MSG_DONE
 echo -e $LINE
 
 # Special paths
-cd _posts/events
+cd events
 echo -e $MSG_START
 git fetch
 git rebase
@@ -65,7 +65,7 @@ echo -e $MSG_DONE
 echo -e $LINE
 cd ../
 
-cd _posts/jobs
+cd jobs
 echo -e $MSG_START
 git fetch
 git rebase

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -57,13 +57,6 @@ echo -e $MSG_DONE
 echo -e $LINE
 
 # Special paths
-cd events
-echo -e $MSG_START
-git fetch
-git rebase
-echo -e $MSG_DONE
-echo -e $LINE
-cd ../
 
 cd jobs
 echo -e $MSG_START


### PR DESCRIPTION
So that when `./scripts/install.sh` is used without additional argument, it assumes opensourcedesign as user and takes the main repos. :)

(In the update script this was already the case.)