### PR TITLE
fixed #166 filtering the output array

### DIFF
--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -30,8 +30,9 @@ layout: default
     </div>
     <div class="how_to_apply">
       {% if page.how_to_apply %}
-      <label for="how_to_apply">How to apply:</label>
-        {{ page.how_to_apply }}
+				<label for="how_to_apply">How to apply:</label>
+				<br>
+				{{ page.how_to_apply | join: "<br>"}}
       {% endif %}
     </div>
     <div class="links">


### PR DESCRIPTION
The `join:` filter prints each string of the array with a `<br>` tag in between.
[Liquid docs](http://shopify.github.io/liquid/filters/join/) and issue #166 for more details.