### PR TITLE
Change link to patterntap, it's confusing

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -94,7 +94,7 @@ issues](https://github.com/nextcloud/core/issues?labels=Design).
 ## Inspiration
 
 * [UI Interaction Library](http://useyourinterface.com/)
-* [Pattern Tap](http://patterntap.com/)
+* [Pattern Tap](https://patterntap.com/patterntap)
 * [Codrops](http://tympanus.net/codrops/)
 
 


### PR DESCRIPTION
patterntap.com on its own says there isn't much going on in the page and links back to the main zurb page. Making it seem like the content doesn't exist anymore.

Linking to patterntap.com/patterntap shows the patterns one would expect, so viewers don't have to go search/wonder where the content moved.