### PR TITLE
Updated index.html 'Become a sponsor' image object

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@ layout: default
               <a title="Stickermule" href="httsp://stickermule.com/supports/opensourcedesign19-sponsorship" target="_blank" rel="noopener"><img src="images/supporters/stickermule.svg" height="40px" width="auto" alt="Stickermule Logo"/></a>
               <img src="images/supporters/wikimedia-germany.svg" height="50px" width="auto" alt="Wikimedia Germany Logo"/>
               <br>
-              <object type="image/svg+xml" data="https://opencollective.com/opensourcedesign/tiers/sponsor.svg?avatarHeight=70&width=150"></object>
+              <object type="image/svg+xml" data="https://opencollective.com/opensourcedesign/tiers/sponsor.svg?avatarHeight=70&width=140"></object>
         </div>
         <div class="col-sm-12 supporters">
               <object type="image/svg+xml" id="lastOne" data="https://opencollective.com/opensourcedesign/tiers/backer.svg?avatarHeight=50&width=400"></object>


### PR DESCRIPTION
Fixes #285 

### Styled an image object by reducing its width as it is left-indent a bit.

- Change its width from 150 to 140 to align it in the center.