### PR TITLE
Update clone repo command and directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ sudo gem install bundler
 2. Fork and clone the main website repository
 
 ```sh
-git clone git@github.com:opensourcedesign/opensourcedesign.net
-cd opensourcedesign.net/
+git clone --single-branch --branch master https://github.com/opensourcedesign/opensourcedesign.github.io.git
+cd opensourcedesign.github.io/
 bundle install
 ```
 


### PR DESCRIPTION
- looks like the repo URL was changed but not the command. 
- A directory name was updated
- added --single-branch flag so that anyone can clone a single repo. "Master" in this case. It reduces cloning time significantly.