### PR TITLE
Unfeature organizations which sponsor only for advertisement

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,18 +87,9 @@ Thank you to **all our backers**! 🙏 ([Become a backer](https://opencollective
 
 <a href="https://opencollective.com/opensourcedesign#backers" target="_blank"><img src="https://opencollective.com/opensourcedesign/backers.svg?width=890"></a>
 
-**Support this project by becoming a sponsor.** Your logo will show up here with a link to your website. ([Become a sponsor](https://opencollective.com/opensourcedesign#sponsor))
+**Support this project by becoming a sponsor.** ([Become a sponsor](https://opencollective.com/opensourcedesign#sponsor))
 
 <a href="https://opencollective.com/opensourcedesign/sponsor/0/website" target="_blank"><img src="https://opencollective.com/opensourcedesign/sponsor/0/avatar.svg"></a>
-<a href="https://opencollective.com/opensourcedesign/sponsor/1/website" target="_blank"><img src="https://opencollective.com/opensourcedesign/sponsor/1/avatar.svg"></a>
-<a href="https://opencollective.com/opensourcedesign/sponsor/2/website" target="_blank"><img src="https://opencollective.com/opensourcedesign/sponsor/2/avatar.svg"></a>
-<a href="https://opencollective.com/opensourcedesign/sponsor/3/website" target="_blank"><img src="https://opencollective.com/opensourcedesign/sponsor/3/avatar.svg"></a>
-<a href="https://opencollective.com/opensourcedesign/sponsor/4/website" target="_blank"><img src="https://opencollective.com/opensourcedesign/sponsor/4/avatar.svg"></a>
-<a href="https://opencollective.com/opensourcedesign/sponsor/5/website" target="_blank"><img src="https://opencollective.com/opensourcedesign/sponsor/5/avatar.svg"></a>
-<a href="https://opencollective.com/opensourcedesign/sponsor/6/website" target="_blank"><img src="https://opencollective.com/opensourcedesign/sponsor/6/avatar.svg"></a>
-<a href="https://opencollective.com/opensourcedesign/sponsor/7/website" target="_blank"><img src="https://opencollective.com/opensourcedesign/sponsor/7/avatar.svg"></a>
-<a href="https://opencollective.com/opensourcedesign/sponsor/8/website" target="_blank"><img src="https://opencollective.com/opensourcedesign/sponsor/8/avatar.svg"></a>
-<a href="https://opencollective.com/opensourcedesign/sponsor/9/website" target="_blank"><img src="https://opencollective.com/opensourcedesign/sponsor/9/avatar.svg"></a>
 
 
 ## ♥ Code of Conduct

--- a/_sass/_front_page.scss
+++ b/_sass/_front_page.scss
@@ -189,14 +189,15 @@ ul.banner-social-buttons {
   & img {
     margin: 25px;
   }
+
+  &.backers object {
+    width: 400px;
+    height: 280px;
+  }
 }
 
 @media(max-width: $screen-xs-max) {
   .supporters {
     margin-bottom: 20px;
-  }
-  #lastOne {
-    text-align: center;
-    margin-top: 15px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -69,9 +69,9 @@ layout: default
               <br>
               <object type="image/svg+xml" data="https://opencollective.com/opensourcedesign/tiers/sponsor.svg?avatarHeight=70&width=150"></object>
         </div>
-        <div class="col-sm-12 supporters">
+        <div class="col-sm-12 supporters backers">
               <h2>Contributors &amp; Backers</h2>
-              <object type="image/svg+xml" id="lastOne" data="https://opencollective.com/opensourcedesign/tiers/backer.svg?avatarHeight=50&width=400"></object>
+              <object type="image/svg+xml" data="https://opencollective.com/opensourcedesign/backer.svg?avatarHeight=50&width=400"></object>
         </div>
     </div>
     <div class="row">


### PR DESCRIPTION
To fix our casino advertisement issue, both on our frontpage and in our readme.

Before (gambling ads) | After (mostly real people)
-|-
![image](https://user-images.githubusercontent.com/925062/103814803-a0386680-5062-11eb-85ab-0f3b79186203.png)|![image](https://user-images.githubusercontent.com/925062/103814750-8434c500-5062-11eb-83c7-ed26d902d952.png)

(The issue why the other widget was not working before was because of the `id="lastOne"` in the object – not sure why though.)
