### PR TITLE
Added correct link fixed #337

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -34,7 +34,7 @@ Jobs submitted to Open Source Design which end up on the public job board
 Events that are relevant and relate to design and open source and design
 
 - [Browse Events](http://opensourcedesign.net/events) to attend something near you
-- [Add an Event](https://github.com/opensourcedesign/events) to help organize new events
+- [Add an Event](https://github.com/opensourcedesign/opensourcedesign.github.io/tree/master/_events) to help organize new events
 
 ### Organization
 


### PR DESCRIPTION
Added the correct link for the "Add an Event to help organize new events" link on the contribute page.