### PR TITLE
Update calendar link to Open Source Design Nextcloud instance

### DIFF
--- a/events/osd-recurring-online-meeting.md
+++ b/events/osd-recurring-online-meeting.md
@@ -15,4 +15,4 @@ These monthly meetings happen as a voice/video call using Jitsi at [meet.jit.si/
 
 To see what we talked about in previous meetings, check out the ["Monthly call" category on the forum](https://discourse.opensourcedesign.net/c/meta/monthly-call).
 
-To get notifications of this meeting and other events, you can subscribe to our Open Source Design events calendar: [Open Source Design calendar](https://cloud.nextcloud.com/index.php/apps/calendar/p/MIFAFLFJADIVX63I/Open-Source-Design)
+To get notifications of this meeting and other events, you can subscribe to our Open Source Design events calendar: [Open Source Design calendar](https://cloud.opensourcedesign.net/apps/calendar/p/CqJYyXyYsFqfPsfr)


### PR DESCRIPTION
Just caught this when chatting with @nimishavijay about the monthly meeting. Will change any links I find in the forum thread too. :)