### PR TITLE
Add Tabler Icons to Resources (plus minor cleanup)

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -24,10 +24,11 @@ German artist. Free to use without attribution and free to modify.
 * [Remix Icons](https://remixicon.com/) Huge repo of consistent neutrally styled icons. [GitHub](https://github.com/Remix-Design/remixicon)
 * [React Icons](https://react-icons.github.io/react-icons/) SVG react icons of popular icon packs. [GitHub](https://github.com/react-icons/react-icons)
 * [Styled Icons](https://styled-icons.js.org/) Icon packs like Font Awesome, Material Design, and Octicons, available as React Styled Components. [GitHub](https://github.com/jacobwgillespie/styled-icons)
-* [React Feather Icons](https://www.npmjs.com/package/react-feather) Collection of simply beautiful open source icons for React.js. [GitHub](React component for Feather icons)
-* [Mono Icons](https://icons.mono.company) A simple, consistent open-source icon set designed to be used in a wide variety of digital products. MIT Licensed. [GitHub](https://github.com/mono-company/mono-icons)
-* [Iconoir](https://iconoir.com/) SVG. MIT license 
-* [Bitcoin icons](https://bitcoinicons.com/) Open source icons made for Bitcoin applications, free to use. MIT license. 
+* [React Feather Icons](https://www.npmjs.com/package/react-feather) Collection of simply beautiful open source icons for React.js. [GitHub](https://github.com/feathericons/react-feather)
+* [Mono Icons](https://icons.mono.company) A simple, consistent open-source icon set designed to be used in a wide variety of digital products. MIT licensed. [GitHub](https://github.com/mono-company/mono-icons)
+* [Iconoir](https://iconoir.com/) SVG. MIT licensed.
+* [Bitcoin Icons](https://bitcoinicons.com/) Open source icons made for Bitcoin applications, free to use. MIT licensed. 
+* [Tabler Icons](https://tabler-icons.io/) Open source SVG icons in a visually consistent style. MIT licensed. [GitHub](https://github.com/tabler/tabler-icons)
 
 
 ## Fonts


### PR DESCRIPTION
I am not in any way affiliated with Tabler... I just like using their icons.

Additionally, I cleaned up some mixed case on the word "icons", mixed formatting on the term "MIT licensed." And I corrected a broken link to another icon set's GitHub.