### PR TITLE
Add link to community calendar on the home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,10 @@ layout: default
             <h2>Events</h2>
             <p>We run events around the world related to open source, design, and more!</p>
             <a href="/events">See all events</a>
+	    <br /><br />
+            <h2>Community calendar</h2>
+            <p>Subscribe and join our monthly community calls.</p>
+            <a href="https://cloud.opensourcedesign.net/apps/calendar/p/CqJYyXyYsFqfPsfr/dayGridMonth/now">See calendar</a>
         </div>
         <div class="col-md-4">
             <h2>Jobs &amp; Projects</h2>


### PR DESCRIPTION
Gives the calendar, and the included calls, more visibility.