### PR TITLE
Add Elementary OS to the project list

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -25,3 +25,4 @@ permalink: /projects/
 * [Trustroots](https://www.trustroots.org/) hospitality platform
 * [Automattic](https://automattic.com/) the company behind WordPress.com, WooCommerce.com, Jetpack.com. [Design blog](https://automattic.design/)
 * [XWiki](https://www.xwiki.org) development platform. [Design wiki](https://design.xwiki.org)
+* [Elementary OS](https://elementary.io/en/) Linux distribution. [Design wiki](https://docs.elementary.io/hig/), [Design blog](https://blog.elementary.io/tags/#design)


### PR DESCRIPTION
This seeks to add [Elementary OS](https://elementary.io/en/) to the [project list](https://github.com/opensourcedesign/opensourcedesign.github.io/blob/master/projects.md).