### PR TITLE
Updates jobs link to point to discourse post

### DIFF
--- a/_data/global.yml
+++ b/_data/global.yml
@@ -8,7 +8,7 @@ header_links:
   - name: Projects
     url: /projects/
   - name: Jobs
-    url: /jobs/
+    url: https://discourse.opensourcedesign.net/t/post-jobs-here-for-now/3416
   - name: Events
     url: /events/
   - name: Forum


### PR DESCRIPTION
Since our jobs board form has been down for a while @jdittrich created a discourse post temporarily for posting jobs. Updating the link for "jobs" in the top navigation of the website to point to that discourse post.