### PR TITLE
Remove `<p>` HTML element displayed in Goals page

### DIFF
--- a/goals.md
+++ b/goals.md
@@ -47,5 +47,5 @@ We plan to achieve this by creating an awesome and inclusive community that attr
 ---------------------------------------
 
 
-*<p align="center">You would also like to have a look at the Open Design Foundation, fine folks there are doing some awesome works, similar to our goals.<br/>
-Open Design Foundation website has gone down due some reason, but we have an [archive of the site](https://web.archive.org/web/20210125021057/http://opendesign.foundation/) on our Wayback Machine and checkout their [Github repository](https://github.com/DesignOpen/designopen.github.io). </p>*
+*You would also like to have a look at the Open Design Foundation, fine folks there are doing some awesome works, similar to our goals.<br/>
+Open Design Foundation website has gone down due some reason, but we have an [archive of the site](https://web.archive.org/web/20210125021057/http://opendesign.foundation/) on our Wayback Machine and checkout their [GitHub repository](https://github.com/DesignOpen/designopen.github.io).*


### PR DESCRIPTION
The [Goals page](https://opensourcedesign.net/goals/) renders `<p align="center">` in the last "How We Plan To Achieve This" section:

<img width="743" alt="Screenshot 2023-05-06 at 09 07 13" src="https://user-images.githubusercontent.com/17381666/236609072-7667806b-67fe-41d2-bdf5-fa06c4e92853.png">

This PR suggests:
- to remove the surrounding `<p align="center">` to let the content in italics and the links in Markdown format
- to fix the typo "Github" → "GitHub"

It would be possible to have the paragraph centered, but it would mean creating the links with `<a>` which is maybe something you don't want, IDK.