### PR TITLE
Changed the link in the HP

### DIFF
--- a/_data/global.yml
+++ b/_data/global.yml
@@ -6,7 +6,7 @@ header_links:
   - name: Resources
     url: /resources/
   - name: Jobs
-    url: https://discourse.opensourcedesign.net/t/post-jobs-here-for-now/3416
+    url: https://opensourcedesign.net/jobs/
   - name: Events
     url: /events/
   - name: Forum


### PR DESCRIPTION
Changed the link the in global Yaml to not be he discourse post and to be jobs page again!

https://opensourcedesign.net/jobs/