### PR TITLE
Modified OC logo to go white on hover

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -223,6 +223,16 @@ a {
   }
 }
 
+.btn-lg svg {
+  width: 1.25em;
+  height: 1em;
+  transition: fill 0.3s ease-in-out;
+}
+
+.btn-lg:hover svg path {
+  fill: white;
+}
+
 /**
  * Paragraphs
  */

--- a/index.html
+++ b/index.html
@@ -151,9 +151,10 @@ layout: default
                 </li>
                 <li>
                     <a href="//opencollective.com/opensourcedesign" class="btn btn-default btn-lg">
-                        <i style="display: inline-flex; align-self: center;transform: translateY(0.125em);">
-                         {% include img/opencollective-logo.svg %}
-                        </i> <span class="network-name">Open Collective</span>
+                        <svg style="display: inline-flex; align-self: center; transform: translateY(0.125em);">
+                            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1.3em" height="1em" version="1.1" viewBox="0 0 40 40"><g id="Page-1" fill="none" fill-rule="evenodd" stroke="none" stroke-width="1"><g id="opencollective-logo"><g id="icon" transform="translate(0.000000, 0.000000)"><path id="Combined-Shape-Copy-2" fill="#7FADF2" d="M34.6194245,8.17880011 C36.7508489,11.2495266 38,14.9788859 38,19 C38,23.0211141 36.7508489,26.7504734 34.6194245,29.8211999 L29.6976779,24.8994533 C30.6641742,23.1506053 31.2142857,21.1395454 31.2142857,19 C31.2142857,16.8604546 30.6641742,14.8493947 29.6976779,13.1005467 L34.6194245,8.17880011 Z M29.8211999,3.38057552 L24.8994533,8.30232215 C23.1506053,7.33582578 21.1395454,6.78571429 19,6.78571429 C12.2542363,6.78571429 6.78571429,12.2542363 6.78571429,19 C6.78571429,25.7457637 12.2542363,31.2142857 19,31.2142857 C21.1395454,31.2142857 23.1506053,30.6641742 24.8994533,29.6976779 L29.8211999,34.6194245 C26.7504734,36.7508489 23.0211141,38 19,38 C8.50658975,38 0,29.4934102 0,19 C0,8.50658975 8.50658975,0 19,0 C23.0211141,0 26.7504734,1.24915112 29.8211999,3.38057552 Z"/><path id="closing-o" fill="#B8D3F4" d="M34.6194245,8.17880011 C36.7508489,11.2495266 38,14.9788859 38,19 C38,23.0211141 36.7508489,26.7504734 34.6194245,29.8211999 L29.6976779,24.8994533 C30.6641742,23.1506053 31.2142857,21.1395454 31.2142857,19 C31.2142857,16.8604546 30.6641742,14.8493947 29.6976779,13.1005467 L34.6194245,8.17880011 Z"/></g></g></g></svg>
+                        </svg>
+                        <span class="network-name">Open Collective</span>
                     </a>
                 </li>
                 <li>


### PR DESCRIPTION
I moved the Open Collective logo SVG to the base HTML file.
I extended the button lg. class for SVGs - one for hover, one for default.
This was to ensure the SVG matched the Font Awesome icons.
Now SVG goes white on hover, corresponding with other boxes.