### PR TITLE
Remove old comment from staticman config

### DIFF
--- a/staticman.yml
+++ b/staticman.yml
@@ -78,5 +78,5 @@ people:
   transforms:
     description: frontmatterContent
 
-  # Sets the title for the commit. Doesn't work yet. https://github.com/eduardoboucas/staticman/issues/79
+  # Sets the title for the commit.
   commitMessage: "New Person - {fields.name}"


### PR DESCRIPTION
Fix #460. As noted by @furmak331 and @SaptakS:

- The comment was referring to a problem in staticman which was fixed upstream in Feb 2017: https://github.com/eduardoboucas/staticman/issues/79#issuecomment-282497367
- We can see new jobs are being created with the right titles in the commit messages, e.g. https://github.com/opensourcedesign/jobs/pull/946

The comment was probably originally included in an example staticman config that was then copied to this repo years ago. Staticman's example config also no longer has the comment: https://github.com/eduardoboucas/staticman/blob/5d7ed7708775e3d4864382cca88d2d73ff875864/staticman.sample.yml#L18