### PR TITLE
Fix 'Become a sponsor' button sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@ layout: default
 				<img src="images/supporters/wikimedia-germany.svg" height="50px" width="auto" alt="Wikimedia Germany"/>
 			</a>
 			<br>
-			<object title="become a sponsor" type="image/svg+xml" data="https://opencollective.com/opensourcedesign/tiers/sponsor.svg?avatarHeight=70&width=150"></object>
+			<object title="become a sponsor" type="image/svg+xml" data="https://opencollective.com/opensourcedesign/tiers/sponsor.svg?avatarHeight=70&width=150" width="141" height="80"></object>
         </div>
         <div class="col-sm-12 supporters backers">
               <h2>Contributors &amp; Backers</h2>


### PR DESCRIPTION
Fix #285. It looks like the svg provided by opencollective does not size itself with an equal border around all edges. Hard-code the size on our side to fix this.

With this change it looks much better:

![image](https://github.com/user-attachments/assets/b7d7f569-d080-43d8-9788-e6916e0abd18)
