### PR TITLE
fix: Restructure Website: Archive "Goals" #500

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ _talks/
 vendor
 CNAME
 /**/*.DS_Store
+.ruby-version

--- a/_data/global.yml
+++ b/_data/global.yml
@@ -1,6 +1,4 @@
 header_links:
-  - name: Goals
-    url: /goals/
   - name: Articles
     url: /articles/
   - name: Resources

--- a/goals.md
+++ b/goals.md
@@ -4,6 +4,8 @@ title: Goals
 permalink: /goals/
 ---
 
+#### ❗This document is currently not being actively maintained. Please contact [@opensourcedesign](https://mastodon.social/@opensourcedesign) for further information
+
 # What We Want to Achieve
 
 ## 1. Open up the design process
@@ -48,4 +50,4 @@ We plan to achieve this by creating an awesome and inclusive community that attr
 
 
 *You would also like to have a look at the Open Design Foundation, fine folks there are doing some awesome works, similar to our goals.<br/>
-Open Design Foundation website has gone down due some reason, but we have an [archive of the site](https://web.archive.org/web/20210125021057/http://opendesign.foundation/) on our Wayback Machine and checkout their [GitHub repository](https://github.com/DesignOpen/designopen.github.io).*
+Open Design Foundation website has gone down due to some reason, but we have an [archive of the site](https://web.archive.org/web/20210125021057/http://opendesign.foundation/) on our Wayback Machine and checkout their [GitHub repository](https://github.com/DesignOpen/designopen.github.io).*

--- a/goals.md
+++ b/goals.md
@@ -4,7 +4,7 @@ title: Goals
 permalink: /goals/
 ---
 
-#### ❗This document is currently not being actively maintained. Please contact [@opensourcedesign](https://mastodon.social/@opensourcedesign) for further information
+#### ❗This document is currently not being actively maintained.
 
 # What We Want to Achieve
 


### PR DESCRIPTION
### Fixes #500 - Archive "Goals"

**Changes**
-  'Goals' has been removed from menu
-  The 'goals.md' document has been updated to show that it is currently not being maintained

No links have been changed, and the '/goals' link still works as expected