### PR TITLE
Add BulkPicTools to Design tools — free browser-based bulk image proc…

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -113,6 +113,7 @@ work needed.
 * [Quant UX](https://www.quant-ux.com/#/) (mockups, UX testing, heatmaps)
 * [Krita](https://krita.org/en/) (art, digital painting)
 * [Blender](https://www.blender.org/) (3d rendering, animation, textures)
+* [BulkPicTools](https://bulkpictools.com) Free browser-based bulk image processor. Compress, convert, resize, and crop 1,000+ images at once — no upload, no account, works offline.
 * [darktable](https://www.darktable.org/) (photo workflow)
 * [RawTherapee](https://www.rawtherapee.com) (photo workflow)
 * [digiKam](https://www.digikam.org/) (photo management)


### PR DESCRIPTION
…essor

## What and Why

Adding BulkPicTools (https://bulkpictools.com) to the Design tools section.

It fills a gap in the current list: the existing tools (GIMP, Inkscape, darktable)  are all desktop applications. BulkPicTools is a free, browser-based alternative  for bulk image processing — compress, resize, convert, crop, and watermark  1,000+ images at once, with no file upload to a server and no account required.

It runs entirely client-side (WebAssembly), which aligns well with the  open source community's values around privacy and local data control.

## Checklist

- [x] Follows existing list format (bullet + link + short description)
- [x] Tool is free to use, no account required
- [x] Inserted in alphabetical order (before Blender)
- [x] Not a duplicate of existing entries