### PR TITLE
Remove redundant footer from Events page

### DIFF
--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -156,10 +156,5 @@
         {{ end }}
       </ul>
     </section>
-
-    {{/* Footer - How to Add Events */}}
-    {{ partial "section-footer.html" (dict "items" (slice
-      (dict "icon" "plus" "text" "To add an event," "linkText" "fork us on GitHub" "href" (site.Params.repoURL | default "https://github.com/opensourcedesign/opensourcedesign.net"))
-    )) }}
   </div>
 {{ end }}


### PR DESCRIPTION
Closes: Remove "To add an event, fork us on Github" on Events page; we now have the form instead Fixes #587

My first contribution! Relatively simple but I will see about tackling other issues in my free time 🫡