### PR TITLE
docs: edit job posting guide and update navigation links

### DIFF
--- a/content/jobs/_index.md
+++ b/content/jobs/_index.md
@@ -4,4 +4,4 @@ description: "Find and post open source design jobs, free and paid."
 outputs: ["html", "rss", "paidrss", "volunteerrss", "json"]
 ---
 
-Find and post open source design jobs, free and paid.
+Find and post open source design jobs, free and paid. Looking to hire? Read our [Job Posting Guide](/jobs/writing-job-posts/).

--- a/content/jobs/writing-job-posts.md
+++ b/content/jobs/writing-job-posts.md
@@ -2,32 +2,19 @@
 title: "OSS Projects: Here's how to make a successful job post"
 date: 2024-05-09
 author: Aila Araghi
+url: /jobs/writing-job-posts/
+type: page
 ---
 
 ## Introduction
 
 Hello everyone! If you plan on publishing a job post on the OpenSource Design website, here are a few steps that can improve your post's coherence and visibility. An effective job post is not just about listing the requirements; it's about engaging with the community, being transparent about the role, and inviting potential collaborators to join your OSS journey.
 
-## Job Post Template
+## How to Submit Your Job Post
 
-When creating your job post, please use the following template to ensure all necessary information is included:
+The easiest and recommended way to publish a job is by using our [Online Job Form](/jobs/job-form/). The form will guide you through the necessary details, provide a live preview, and automatically create the GitHub Pull Request for you.
 
-- _id: [Unique Identifier]
-- layout: jobs
-- title: [Brief, Descriptive Job Title]
-- role: [Specific Job Role]
-- organisation: [Your Organization's Name]
-- github: [Your GitHub Username]
-- contact: [Your Contact Info – Email, GitHub, IRC, etc.]
-- contributing_md: [Optional Link to Contributing Guidelines]
-- contributors_md: [Optional List of Reachable Contributors]
-- org_url: [Your Organization's Website]
-- tags: [Relevant Tags like 'interface design', 'branding', 'logo']
-- status: [Searching or Hired]
-- compensation: [Compensation Info – Gratis, Paid, etc.]
-- date_posted: [Posting Date in yyyy-mm-dd Format]
-
-**Note:** Replace the bracketed content with your specific job details.
+To make sure your post is effective and welcoming, we've put together the following step-by-step guide on what to include in your job description.
 
 ## Step-by-Step Guide
 

--- a/layouts/jobs/job-form.html
+++ b/layouts/jobs/job-form.html
@@ -19,6 +19,14 @@
         <span id="osd-edit-banner-text"></span>
       </p>
 
+      {{/* Writing Guide Hint */}}
+      <p class="mt-6 flex items-start gap-2 rounded-lg bg-sky-50 px-3 py-2 text-sm text-sky-800 ring-1 ring-inset ring-sky-200">
+        <svg class="mt-0.5 h-4 w-4 shrink-0 text-sky-600" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+        </svg>
+        <span>First time posting? Read our <a class="font-semibold underline decoration-sky-400 underline-offset-4 transition hover:decoration-sky-800" href="{{ partial "site-path.html" "/jobs/writing-job-posts/" }}">Job Posting Guide</a>.</span>
+      </p>
+
       {{/* Guidelines */}}
       <p class="mt-6 flex items-start gap-2 rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-800 ring-1 ring-inset ring-amber-200">
         <svg class="mt-0.5 h-4 w-4 shrink-0 text-amber-600" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">


### PR DESCRIPTION
### Description
Updates the "How to make a successful job post" guide to reflect the current online job form workflow and removes legacy instructions about manual PR creation.

- Set `type: page` on guide content for proper full-page layout rendering.
- Edit the markdown writing-job-posts.md
- Added a guide banner in `layouts/jobs/job-form.html`.
- Added reference link in content/jobs/_index.md (open to removing if redundant).

Closes #594